### PR TITLE
Set apex fitting position manually

### DIFF
--- a/addons/slingload/functions/fnc_rigCargo.sqf
+++ b/addons/slingload/functions/fnc_rigCargo.sqf
@@ -42,7 +42,8 @@ if (damage _cargo == 1) then {
     _cargo = _helper;
 };
 
-_apexFitting = createVehicle ["slr_slingload_apexFitting", _cargo modelToWorldVisual (boundingBoxReal _cargo # 1), [], 0, "CAN_COLLIDE"];
+_apexFitting = createVehicle ["slr_slingload_apexFitting", [0,0,0], [], 0, "CAN_COLLIDE"];
+_apexFitting setPosWorld (_cargo modelToWorldVisualWorld (boundingBoxReal _cargo # 1));
 _apexFitting allowDamage false;
 _apexFitting disableCollisionWith _cargo;
 _apexFitting disableCollisionWith _unit;


### PR DESCRIPTION
**When merged this pull request will:**
- When rigging an item, create the apex fitting at 0,0,0 then set its position manually to get around problems with position formats
- Fix #4 